### PR TITLE
Fixed ad styling.

### DIFF
--- a/templates/traffective-adslot.html.twig
+++ b/templates/traffective-adslot.html.twig
@@ -21,8 +21,10 @@
     <div id="{{ format }}-{{ render_count }}"></div>
   {% elseif 'halfpage' in format %}
     <div id="traffective-ad-{{ format|title }}Ad" style="display: none;" class="{{ format|title }}Ad"></div>
-  {% elseif format|lower in ['skyscraper', 'wpskyscraper'] %}
+  {% elseif 'wpskyscraper' in format|lower %}
     <div id="traffective-ad-{{ format }}" style="display: none;" class='{{ format }}'></div>
+  {% elseif 'skyscraper' in format|lower %}
+    <div id="traffective-ad-{{ format|title }}" style="display: none;" class='{{ format|title }}'></div>
   {% else %}
     <div id="traffective-ad-{{ format|title }}{% if format != 'mobile_pos' %}_{% endif %}{{ render_count }}" style="display: none;" class="{{ format|title }}{% if format != 'mobile_pos' %}_{% endif %}{{ render_count }}"></div>
   {% endif %}

--- a/templates/traffective-adslot.html.twig
+++ b/templates/traffective-adslot.html.twig
@@ -21,7 +21,7 @@
     <div id="{{ format }}-{{ render_count }}"></div>
   {% elseif 'halfpage' in format %}
     <div id="traffective-ad-{{ format|title }}Ad" style="display: none;" class="{{ format|title }}Ad"></div>
-  {% elseif 'wpskyscraper' in format|lower %}
+  {% elseif format|lower in ['skyscraper', 'wpskyscraper'] %}
     <div id="traffective-ad-{{ format }}" style="display: none;" class='{{ format }}'></div>
   {% else %}
     <div id="traffective-ad-{{ format|title }}{% if format != 'mobile_pos' %}_{% endif %}{{ render_count }}" style="display: none;" class="{{ format|title }}{% if format != 'mobile_pos' %}_{% endif %}{{ render_count }}"></div>

--- a/templates/traffective-adslot.html.twig
+++ b/templates/traffective-adslot.html.twig
@@ -13,17 +13,16 @@
 {% set classes = [
   'traffective-adslot',
   ' ad',
-  ' ad--' ~ format,
+  ' ad--' ~ format|lower,
 ] %}
 <div class="{{ classes|join }}">
   {# Extract "nativendo" ads into own Drupal module #}
   {% if 'native' in format %}
     <div id="{{ format }}-{{ render_count }}"></div>
-  {% elseif format in ['skyscraper', 'halfpage'] %}
-    {% if format in ['skyscraper'] %}
-      <div id="traffective-ad-WP{{ format|title }}" style="display: none;" class='WP{{ format|title }}'></div>
-    {% endif %}
-    <div id="traffective-ad-{{ format|title }}{% if format in ['halfpage'] %}Ad{% endif %}" style="display: none;" class="{{ format|title }}{% if format in ['halfpage'] %}Ad{% endif %}"></div>
+  {% elseif 'halfpage' in format %}
+    <div id="traffective-ad-{{ format|title }}Ad" style="display: none;" class="{{ format|title }}Ad"></div>
+  {% elseif 'wpskyscraper' in format|lower %}
+    <div id="traffective-ad-{{ format }}" style="display: none;" class='{{ format }}'></div>
   {% else %}
     <div id="traffective-ad-{{ format|title }}{% if format != 'mobile_pos' %}_{% endif %}{{ render_count }}" style="display: none;" class="{{ format|title }}{% if format != 'mobile_pos' %}_{% endif %}{{ render_count }}"></div>
   {% endif %}

--- a/traffective.module
+++ b/traffective.module
@@ -493,7 +493,7 @@ function traffective_views_post_execute($view) {
   // alternate with the native ads.
   $view_render = &drupal_static('views_render_count', 0);
   if ($view_render === 0) {
-    $view->element['content']['skyscraper'] = AdSlot::render('skyscraper');
+    $view->element['content']['skyscraper'] = AdSlot::render('Skyscraper');
     $view->element['content']['skyscraper']['#weight'] = -1;
   }
   if ($view_render % 2 === 0) {

--- a/traffective.module
+++ b/traffective.module
@@ -492,7 +492,7 @@ function traffective_views_post_execute($view) {
   // alternate with the native ads.
   $view_render = &drupal_static('views_render_count', 0);
   if ($view_render === 0) {
-    $view->element['content']['skyscraper'] = AdSlot::render('Skyscraper');
+    $view->element['content']['skyscraper'] = AdSlot::render('skyscraper');
     $view->element['content']['skyscraper']['#weight'] = -1;
   }
   if ($view_render % 2 === 0) {

--- a/traffective.module
+++ b/traffective.module
@@ -361,7 +361,6 @@ function traffective_node_view_alter(array &$build, EntityInterface $entity, Ent
         ) {
           $build['field_paragraphs'][$key][] = [
             AdSlot::render('content'),
-            AdSlot::render('mobile_pos'),
           ];
           $parallax_ad_slot->setPlaced($paragraph_count);
           $previous_offset = $paragraph_count;

--- a/traffective.module
+++ b/traffective.module
@@ -492,12 +492,16 @@ function traffective_views_post_execute($view) {
   // Render a billboard on top of the first view and after every 2nd to
   // alternate with the native ads.
   $view_render = &drupal_static('views_render_count', 0);
+  if ($view_render === 0) {
+    $view->element['content']['skyscraper'] = AdSlot::render('skyscraper');
+    $view->element['content']['skyscraper']['#weight'] = -1;
+  }
   if ($view_render % 2 === 0) {
-    $view->element['content']['billboard'] = [
+    $ads = [
       AdSlot::render('billboard'),
       AdSlot::render('mobile_pos'),
     ];
-    $view->element['content']['billboard']['#weight'] = -1;
+    $view->element['#prefix'] = \Drupal::service('renderer')->render($ads);
   }
   $view_render++;
 }


### PR DESCRIPTION
- Separated `Skyscraper` and `WPSkyscraper`
- Remove `mobile_pos` for content ads